### PR TITLE
added error checking after session_loop

### DIFF
--- a/session.go
+++ b/session.go
@@ -199,7 +199,7 @@ func (s *Session) frameReceiver(done chan<- bool, incoming chan<- frame) {
 
 	for {
 		frame, err := s.receive()
-		if err == isConnReset(err) {
+		if isConnReset(err) {
 			// normal reasons, like disconnection, etc.
 			break
 		}


### PR DESCRIPTION
Plus dropped io.EOF equality checking since receive() never returns io.EOF. Also dropping of isConnReset and merging into one general if err != nil clause should probably be done, since the result in both cases is the same (break).

UPDATE
isConnReset(err) should be called alone and not in a boolean operation, my bad
