### PR TITLE
Goaway support added

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,14 +150,15 @@ Things implemented:
  * `PING` frames
  * Support for other all types of HTTP requests
  * DATA frames, obviously
+ * `GOAWAY` frame
+ * NPN negotiation
 
 Things to be implemented:
  * Support for SETTINGS frames
  * Actual implementation of priorities (everything is one priority at the moment)
  * Server push
- * GOAWAY and HEADERS frames
+ * HEADERS frames
  * Variable flow control window size
- * NPN negotiation
  * Extensive error handling for all possible rainy-day scenarios specified in the specification
  * Support for pre-3.1 SPDY standards
 

--- a/examples/serverTLS/tlsserver.go
+++ b/examples/serverTLS/tlsserver.go
@@ -11,6 +11,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
+        spdy.EnableDebug()
         http.HandleFunc("/", handler)
 	err := spdy.ListenAndServeTLS("localhost:4040", "server.pem", "server.key" , nil)
 	if err != nil {

--- a/server_conn.go
+++ b/server_conn.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-func (c *conn) handleConnection() {
+func (c *conn) handleConnection(outchan chan *Session) {
 	hserve := new(http.Server)
 	if c.srv.Handler == nil {
 		hserve.Handler = http.DefaultServeMux
@@ -22,6 +22,9 @@ func (c *conn) handleConnection() {
 	}
 	hserve.Addr = c.srv.Addr
 	c.ss = NewServerSession(c.cn, hserve)
+	if outchan != nil {
+		outchan <- c.ss
+	}
 	c.ss.Serve()
 }
 
@@ -68,7 +71,7 @@ func (s *Server) Serve(ln net.Listener) (err error) {
 		if err != nil {
 			continue
 		}
-		go c.handleConnection()
+		go c.handleConnection(s.ss_chan)
 	}
 }
 

--- a/stream.go
+++ b/stream.go
@@ -25,65 +25,76 @@ const NORTHBOUND_SLOTS = 5
 
 // NewClientStream starts a new Stream (in the given Session), to be used as a client
 func (s *Session) NewClientStream() *Stream {
-	str := &Stream{
-		id:                s.nextStreamID(),
-		session:           s,
-		priority:          4, // FIXME need to implement priorities
-		associated_stream: 0, // FIXME for pushes we need to implement it
-		control:           make(chan controlFrame),
-		data:              make(chan dataFrame),
-		response:          make(chan bool),
-		eos:               make(chan bool),
-		stop_server:       make(chan bool),
-		flow_req:          make(chan int32, 1),
-		flow_add:          make(chan int32, 1),
-		upstream_buffer:   make(chan upstream_data, NORTHBOUND_SLOTS),
-	}
+	// no stream creation after goaway has been recieved
+	if !s.goaway_recvd {
+		str := &Stream{
+			id:                s.nextStreamID(),
+			session:           s,
+			priority:          4, // FIXME need to implement priorities
+			associated_stream: 0, // FIXME for pushes we need to implement it
+			control:           make(chan controlFrame),
+			data:              make(chan dataFrame),
+			response:          make(chan bool),
+			eos:               make(chan bool),
+			stop_server:       make(chan bool),
+			flow_req:          make(chan int32, 1),
+			flow_add:          make(chan int32, 1),
+			upstream_buffer:   make(chan upstream_data, NORTHBOUND_SLOTS),
+		}
 
-	go str.serve()
+		go str.serve()
 
-	go str.northboundBufferSender()
+		go str.northboundBufferSender()
 
-	go str.flowManager(INITIAL_FLOW_CONTOL_WINDOW, str.flow_add, str.flow_req)
+		go str.flowManager(INITIAL_FLOW_CONTOL_WINDOW, str.flow_add, str.flow_req)
 
-	// add the stream to the session
+		// add the stream to the session
 
-	deadline := time.After(1500 * time.Millisecond)
-	select {
-	case s.new_stream <- str:
-		// done
-		return str
-	case <-deadline:
-		// somehow it was locked
-		debug.Printf("Stream #%d: cannot be created. Stream is hung. Resetting it.", str.id)
-		s.Close()
+		deadline := time.After(1500 * time.Millisecond)
+		select {
+		case s.new_stream <- str:
+			// done
+			return str
+		case <-deadline:
+			// somehow it was locked
+			debug.Printf("Stream #%d: cannot be created. Stream is hung. Resetting it.", str.id)
+			s.Close()
+			return nil
+		}
+	} else {
+		debug.Println("Cannot create stream after receiving goaway")
 		return nil
 	}
 }
 
 func (s *Session) newServerStream(frame controlFrame) (str *Stream, err error) {
+	// no stream creation after goaway has been recieved
+	if !s.goaway_recvd {
+		str = &Stream{
+			id:                frame.streamID(),
+			session:           s,
+			priority:          4, // FIXME need to implement priorities
+			associated_stream: 0, // FIXME for pushes we need to implement it
+			control:           make(chan controlFrame),
+			data:              make(chan dataFrame),
+			response:          make(chan bool),
+			eos:               make(chan bool),
+			stop_server:       make(chan bool),
+			flow_req:          make(chan int32, 1),
+			flow_add:          make(chan int32, 1),
+		}
 
-	str = &Stream{
-		id:                frame.streamID(),
-		session:           s,
-		priority:          4, // FIXME need to implement priorities
-		associated_stream: 0, // FIXME for pushes we need to implement it
-		control:           make(chan controlFrame),
-		data:              make(chan dataFrame),
-		response:          make(chan bool),
-		eos:               make(chan bool),
-		stop_server:       make(chan bool),
-		flow_req:          make(chan int32, 1),
-		flow_add:          make(chan int32, 1),
+		go str.serve()
+
+		go str.flowManager(INITIAL_FLOW_CONTOL_WINDOW, str.flow_add, str.flow_req)
+
+		// send the SYN_STREAM control frame to get it started
+		str.control <- frame
+		return
+	} else {
+		return nil, errors.New("Cannot create stream after receiving goaway")
 	}
 
-	go str.serve()
-
-	go str.flowManager(INITIAL_FLOW_CONTOL_WINDOW, str.flow_add, str.flow_req)
-
-	// send the SYN_STREAM control frame to get it started
-	str.control <- frame
-	return
 }
 
 // String returns the Stream ID of the Stream
@@ -332,8 +343,8 @@ func (s *Stream) initiate_stream(frame controlFrame) (err error) {
 				}
 				switch cf.kind {
 				case FRAME_SYN_STREAM:
-					err = s.initiate_stream(cf)
-					debug.Println("Goroutines:", runtime.NumGoroutine())
+					err = errors.New("Multiple Syn Streams sent to single Stream")
+					return
 				case FRAME_SYN_REPLY:
 					err = s.handleSynReply(cf)
 				case FRAME_RST_STREAM:
@@ -408,7 +419,6 @@ func (s *Stream) requestHandler(req *http.Request) {
 func (s *Stream) serve() {
 
 	debug.Printf("Stream #%d main loop", s.id)
-	s.closed = false
 	err := s.stream_loop()
 	if err != nil {
 		debug.Println("ERROR in stream loop:", err)

--- a/types.go
+++ b/types.go
@@ -67,6 +67,7 @@ type Session struct {
 	server       *http.Server // http server for this session
 	nextStream   streamID     // the next stream ID
 	closed       bool         // is this session closed?
+	goaway_recvd bool         // recieved goaway
 	headerWriter *headerWriter
 	headerReader *headerReader
 	settings     *settings
@@ -168,6 +169,7 @@ type Server struct {
 	Addr      string
 	TLSConfig *tls.Config
 	ln        net.Listener
+	ss_chan   chan *Session
 }
 
 //spdy conn


### PR DESCRIPTION
After doing a lot of research I am confident that the current version of goaway support is done the right way.
Note that goaway frame support is optional. A spdy end point will optionally send goaway frame before it disconnects. The receiver of goaway frame is supposed to close all streams with id greater than the one present in the frame. This is the only compulsory job an end point has to do.
This PR contains
1. A processGoaway() routine in session.go
2. A test for goaway frames in spdy_test.go
3. Some readme.md updates
4. Some changes in the friendly server. The server now has an optional channel through which it sends all new session objects to the creator of the server to use. (server_conn.go) 
